### PR TITLE
open links in a new tab

### DIFF
--- a/components/Detail.jsx
+++ b/components/Detail.jsx
@@ -28,7 +28,7 @@ const Details = ({ name, ring, quadrant, description, close }) => {
       <dl className="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-1">
         <div className="sm:col-span-1">
           <dd className="mt-1 prose prose-sm max-w-none">
-            <ReactMarkdown>{description}</ReactMarkdown>
+            <ReactMarkdown linkTarget="_blank">{description}</ReactMarkdown>
           </dd>
         </div>
       </dl>

--- a/components/radar/Tooltip.jsx
+++ b/components/radar/Tooltip.jsx
@@ -45,7 +45,7 @@ const Tooltip = ({
           </h4>
           <h3 className="font-medium text-gray-900 mb-2">{name}</h3>
           <p className="text-sm text-gray-500  prose prose-base">
-            <ReactMarkdown>{description}</ReactMarkdown>
+            <ReactMarkdown linkTarget="_blank">{description}</ReactMarkdown>
           </p>
         </div>,
         el


### PR DESCRIPTION
### Motivation 
Open links in a new browser tab instead of navigating away from the Tech Radar.

### Implementation
`ReactMarkdown` supports a `linkTarget` property to define this behavior.