### PR TITLE
add mixpanel integration option

### DIFF
--- a/integrations/mixpanel.js
+++ b/integrations/mixpanel.js
@@ -1,0 +1,24 @@
+import Script from "next/script";
+
+const MixpanelTracking = () => {
+  const shouldMount = typeof window != "undefined" && !window.mixpanel;
+
+  return shouldMount ? (
+    <Script
+      id="mixpanel-tracking"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+          (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+        for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".split(" ");a.get_group=function(){function b(c){d[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));a.push([e,call2])}}for(var d={},e=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<j.length;c++)b(j[c]);return d};b._i.push([e,f,c])};b.__SV=1.2;e=f.createElement("script");e.type="text/javascript";e.async=!0;e.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?
+        MIXPANEL_CUSTOM_LIB_URL:"file:"===f.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\\/\\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";g=f.getElementsByTagName("script")[0];g.parentNode.insertBefore(e,g)}})(document,window.mixpanel||[]);
+        
+        mixpanel.init("${process.env.NEXT_PUBLIC_MIXPANEL_TOKEN}", {debug: false});
+        mixpanel.track("${process.env.NEXT_PUBLIC_TRACK_PAGE_VIEW}");
+`,
+      }}
+    />
+  ) : null;
+};
+
+export default MixpanelTracking;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,17 @@
 import "../styles/globals.css";
 
+const MixpanelTracking =
+  process.env.NEXT_PUBLIC_MIXPANEL_TOKEN &&
+  require("../integrations/mixpanel").default;
+
 function MyApp({ Component, pageProps }) {
   return (
-    <div className="h-full bg-gray-100 min-h-screen max-w-screen overflow-x-clip">
-      <Component {...pageProps} />
-    </div>
+    <>
+      {MixpanelTracking ? <MixpanelTracking /> : null}
+      <div className="h-full bg-gray-100 min-h-screen max-w-screen overflow-x-clip">
+        <Component {...pageProps} />
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
@bennybauer the following PR adds support for Mixpanel.
We can consider a pluggable system in the future if the project is ever used externally, but for now to support Mixpanel one would need to provide - 
NEXT_PUBLIC_MIXPANEL_TOKEN - the Mixpanel project token
NEXT_PUBLIC_TRACK_PAGE_VIEW - the event that is sent for a page view

If the token is not provided Mixpanel will not load on the browser.
The actual import snippet is taken from a Mixpanel <-> Next integration guide.