### PR TITLE
remove un-used import

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import fs from "fs";
 import path from "path";
-import { useState } from "react";
 import csvToJson from "csvtojson";
 
 import Radar from "../components/radar/Radar";


### PR DESCRIPTION
This is a simple PR that removes an unused import in the code.
The reason for the PR is to test out review urls from Vercel.